### PR TITLE
take the last 23 bytes from an id

### DIFF
--- a/src/clojure/clojurewerkz/machine_head/client.clj
+++ b/src/clojure/clojurewerkz/machine_head/client.clj
@@ -45,8 +45,10 @@
 
 (defn ^String generate-id
   "Generates a client id"
+  "Take the last 23 bytes until the Paho bug that enables the generation of long ids is resolved"
   []
-  (MqttClient/generateClientId))
+  (let [id (MqttClient/generateClientId)]
+    (apply str (take-last 23 id))))
 
 (defn connected?
   "Returns true if client is currently connected"


### PR DESCRIPTION
As discussed, short term fix to take the last 23 chars of a client id
