### PR TITLE
fixing readme to reflect version breaking changes from beta-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ definition to your `pom.xml`:
 
 With Leiningen:
 
-    [clojurewerkz/machine_head "1.0.0-beta8"]
+    [clojurewerkz/machine_head "1.0.0-beta9"]
 
 
 With Maven:
@@ -56,7 +56,7 @@ With Maven:
     <dependency>
       <groupId>clojurewerkz</groupId>
       <artifactId>machine_head</artifactId>
-      <version>1.0.0-beta8</version>
+      <version>1.0.0-beta9</version>
     </dependency>
 
 


### PR DESCRIPTION
version beta-8 subscribe signature uses a sequence of topics whereas the beta-9 switches to hashmaps to allow for specifying a QoS. Perhaps in the future, both should be accepted and when QoS is not given, assume 0.

beginning of the breaking change.
https://github.com/hfukada/machine_head/blob/master/src/clojure/clojurewerkz/machine_head/client.clj#L107 