### PR TITLE
Client auto-reconnect option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ script: lein2 all test
 jdk:
   - openjdk7
   - oraclejdk7
+  - openjdk8
+  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,5 @@ services:
 before_script: ./bin/ci/before_script.sh
 script: lein2 all test
 jdk:
-  - openjdk7
   - oraclejdk7
-  - openjdk8
   - oraclejdk8

--- a/Dockerfile-rabbitmq
+++ b/Dockerfile-rabbitmq
@@ -1,0 +1,6 @@
+# RabbitMQ for running the tests
+FROM rabbitmq
+
+RUN rabbitmq-plugins enable --offline rabbitmq_mqtt
+
+EXPOSE 15671 15672

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- # Machine Head, a Clojure MQTT Client
+# Machine Head, a Clojure MQTT Client
 
 Machine Head is a [Clojure MQTT client](http://clojuremqtt.info).
 
@@ -8,7 +8,7 @@ Machine Head is a [Clojure MQTT client](http://clojuremqtt.info).
  * Cover all (or nearly all) MQTT v3 features
  * Be [well documented](http://clojuremqtt.info)
  * Be [well tested](https://github.com/clojurewerkz/machine_head/tree/master/test/clojurewerkz/machine_head)
- * Provide a convenient API
+ * Provide a convenient API (Paho Java's API is poorly designed)
  * Don't introduce a lot of latency and throughput overhead
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  rabbitmq4test:
+    build:
+      context: .
+      dockerfile: ./Dockerfile-rabbitmq
+    hostname: test-rabbit
+    expose: [1883]
+    ports: ["1883:1883"]

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject clojurewerkz/machine_head "1.0.0-beta10-SNAPSHOT"
   :description "Clojure MQTT client"
-  :dependencies [[org.clojure/clojure          "1.6.0"]
-                 [org.eclipse.paho/mqtt-client "0.4.0"]
+  :dependencies [[org.clojure/clojure          "1.8.0"]
+                 [org.eclipse.paho/org.eclipse.paho.client.mqttv3 "1.0.2"]
                  [clojurewerkz/support         "1.1.0"]]
   :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :master {:dependencies [[org.clojure/clojure "1.8.0-master-SNAPSHOT"]]}

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject clojurewerkz/machine_head "1.0.0-beta10-SNAPSHOT"
   :description "Clojure MQTT client"
   :dependencies [[org.clojure/clojure          "1.8.0"]
-                 [org.eclipse.paho/org.eclipse.paho.client.mqttv3 "1.0.2"]
+                 [org.eclipse.paho/org.eclipse.paho.client.mqttv3 "1.1.0"]
                  [clojurewerkz/support         "1.1.0"]]
   :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :master {:dependencies [[org.clojure/clojure "1.8.0-master-SNAPSHOT"]]}

--- a/src/clojure/clojurewerkz/machine_head/client.clj
+++ b/src/clojure/clojurewerkz/machine_head/client.clj
@@ -17,13 +17,14 @@
 (defn ^IMqttClient connect
   "Instantiates a new client and connects to MQTT broker.
 
-   Options:
+   Options: either a map with any of the keys bellow or an instance of MqttConnectOptions
 
     * :username (string)
     * :password (string or char array)
     * :keep-alive-interval (int)
     * :connection-timeout (int)
     * :clean-session (bool)
+    * :socket-factory (SocketFactory)
     * :will {:topic :payload :qos :retain}"
   ([^String uri ^String client-id]
      (doto (prepare uri client-id)

--- a/src/clojure/clojurewerkz/machine_head/client.clj
+++ b/src/clojure/clojurewerkz/machine_head/client.clj
@@ -24,7 +24,6 @@
     * :keep-alive-interval (int)
     * :connection-timeout (int)
     * :clean-session (bool)
-    * :socket-factory (SocketFactory)
     * :will {:topic :payload :qos :retain}
     * :auto-reconnect (bool)"
   ([^String uri ^String client-id]

--- a/src/clojure/clojurewerkz/machine_head/client.clj
+++ b/src/clojure/clojurewerkz/machine_head/client.clj
@@ -24,6 +24,7 @@
     * :keep-alive-interval (int)
     * :connection-timeout (int)
     * :clean-session (bool)
+    * :socket-factory (SocketFactory)
     * :will {:topic :payload :qos :retain}
     * :auto-reconnect (bool)"
   ([^String uri ^String client-id]

--- a/src/clojure/clojurewerkz/machine_head/conversion.clj
+++ b/src/clojure/clojurewerkz/machine_head/conversion.clj
@@ -19,6 +19,8 @@
       (.setConnectionTimeout o (Integer/valueOf t)))
     (when-not (nil? (:clean-session m))
       (.setCleanSession o (:clean-session m)))
+    (when-let [f (:socket-factory m)]
+      (.setSocketFactory o f))
     (when-let [will (:will m)]
       (.setWill ^MqttConnectOptions o
                 ^String (get will :topic)

--- a/src/clojure/clojurewerkz/machine_head/conversion.clj
+++ b/src/clojure/clojurewerkz/machine_head/conversion.clj
@@ -8,26 +8,29 @@
 
 (defn ->connect-options
   [m]
-  (let [o (MqttConnectOptions.)]
-    (when-let [u (:username m)]
-      (.setUserName o u))
-    (when-let [p (to-char-array (:password m))]
-      (.setPassword o p))
-    (when-let [i (:keep-alive-interval m)]
-      (.setKeepAliveInterval o i))
-    (when-let [t (:connection-timeout m)]
-      (.setConnectionTimeout o (Integer/valueOf t)))
-    (when-not (nil? (:clean-session m))
-      (.setCleanSession o (:clean-session m)))
-    (when-let [f (:socket-factory m)]
-      (.setSocketFactory o f))
-    (when-let [will (:will m)]
-      (.setWill ^MqttConnectOptions o
-                ^String (get will :topic)
-                ^bytes (get will :payload (byte-array 0))
-                (Integer/valueOf (get will :qos 0))
-                ^boolean (get will :retain false)))
-    o))
+  {:pre [(or (map? m) (instance? MqttConnectOptions m))]}
+  (if (instance? MqttConnectOptions m)
+    m
+    (let [o (MqttConnectOptions.)]
+     (when-let [u (:username m)]
+       (.setUserName o u))
+     (when-let [p (to-char-array (:password m))]
+       (.setPassword o p))
+     (when-let [i (:keep-alive-interval m)]
+       (.setKeepAliveInterval o i))
+     (when-let [t (:connection-timeout m)]
+       (.setConnectionTimeout o (Integer/valueOf t)))
+     (when-not (nil? (:clean-session m))
+       (.setCleanSession o (:clean-session m)))
+     (when-let [f (:socket-factory m)]
+       (.setSocketFactory o f))
+     (when-let [will (:will m)]
+       (.setWill ^MqttConnectOptions o
+                 ^String (get will :topic)
+                 ^bytes (get will :payload (byte-array 0))
+                 (Integer/valueOf (get will :qos 0))
+                 ^boolean (get will :retain false)))
+     o)))
 
 (defprotocol MessageSource
   (^MqttMessage to-message [input] "Instantiates an MQTT message from input"))

--- a/src/clojure/clojurewerkz/machine_head/conversion.clj
+++ b/src/clojure/clojurewerkz/machine_head/conversion.clj
@@ -8,29 +8,28 @@
 
 (defn ->connect-options
   [m]
-  {:pre [(or (map? m) (instance? MqttConnectOptions m))]}
-  (if (instance? MqttConnectOptions m)
-    m
-    (let [o (MqttConnectOptions.)]
-     (when-let [u (:username m)]
-       (.setUserName o u))
-     (when-let [p (to-char-array (:password m))]
-       (.setPassword o p))
-     (when-let [i (:keep-alive-interval m)]
-       (.setKeepAliveInterval o i))
-     (when-let [t (:connection-timeout m)]
-       (.setConnectionTimeout o (Integer/valueOf t)))
-     (when-not (nil? (:clean-session m))
-       (.setCleanSession o (:clean-session m)))
-     (when-let [f (:socket-factory m)]
-       (.setSocketFactory o f))
-     (when-let [will (:will m)]
-       (.setWill ^MqttConnectOptions o
-                 ^String (get will :topic)
-                 ^bytes (get will :payload (byte-array 0))
-                 (Integer/valueOf (get will :qos 0))
-                 ^boolean (get will :retain false)))
-     o)))
+  (let [o (MqttConnectOptions.)]
+    (when-let [u (:username m)]
+      (.setUserName o u))
+    (when-let [p (to-char-array (:password m))]
+      (.setPassword o p))
+    (when-let [i (:keep-alive-interval m)]
+      (.setKeepAliveInterval o i))
+    (when-let [t (:connection-timeout m)]
+      (.setConnectionTimeout o (Integer/valueOf t)))
+    (when-not (nil? (:clean-session m))
+      (.setCleanSession o (:clean-session m)))
+    (when-let [f (:socket-factory m)]
+      (.setSocketFactory o f))
+    (when-let [will (:will m)]
+      (.setWill ^MqttConnectOptions o
+                ^String (get will :topic)
+                ^bytes (get will :payload (byte-array 0))
+                (Integer/valueOf (get will :qos 0))
+                ^boolean (get will :retain false)))
+    (when-let [r (:auto-reconnect m)]
+      (.setAutomaticReconnect o r))
+    o))
 
 (defprotocol MessageSource
   (^MqttMessage to-message [input] "Instantiates an MQTT message from input"))

--- a/src/clojure/clojurewerkz/machine_head/conversion.clj
+++ b/src/clojure/clojurewerkz/machine_head/conversion.clj
@@ -8,28 +8,31 @@
 
 (defn ->connect-options
   [m]
-  (let [o (MqttConnectOptions.)]
-    (when-let [u (:username m)]
-      (.setUserName o u))
-    (when-let [p (to-char-array (:password m))]
-      (.setPassword o p))
-    (when-let [i (:keep-alive-interval m)]
-      (.setKeepAliveInterval o i))
-    (when-let [t (:connection-timeout m)]
-      (.setConnectionTimeout o (Integer/valueOf t)))
-    (when-not (nil? (:clean-session m))
-      (.setCleanSession o (:clean-session m)))
-    (when-let [f (:socket-factory m)]
-      (.setSocketFactory o f))
-    (when-let [will (:will m)]
-      (.setWill ^MqttConnectOptions o
-                ^String (get will :topic)
-                ^bytes (get will :payload (byte-array 0))
-                (Integer/valueOf (get will :qos 0))
-                ^boolean (get will :retain false)))
-    (when-let [r (:auto-reconnect m)]
-      (.setAutomaticReconnect o r))
-    o))
+  {:pre [(or (map? m) (instance? MqttConnectOptions m))]}
+  (if (instance? MqttConnectOptions m)
+    m
+    (let [o (MqttConnectOptions.)]
+     (when-let [u (:username m)]
+       (.setUserName o u))
+     (when-let [p (to-char-array (:password m))]
+       (.setPassword o p))
+     (when-let [i (:keep-alive-interval m)]
+       (.setKeepAliveInterval o i))
+     (when-let [t (:connection-timeout m)]
+       (.setConnectionTimeout o (Integer/valueOf t)))
+     (when-not (nil? (:clean-session m))
+       (.setCleanSession o (:clean-session m)))
+     (when-let [f (:socket-factory m)]
+       (.setSocketFactory o f))
+     (when-let [will (:will m)]
+       (.setWill ^MqttConnectOptions o
+                 ^String (get will :topic)
+                 ^bytes (get will :payload (byte-array 0))
+                 (Integer/valueOf (get will :qos 0))
+                 ^boolean (get will :retain false)))
+     (when-let [r (:auto-reconnect m)]
+       (.setAutomaticReconnect o r))
+     o)))
 
 (defprotocol MessageSource
   (^MqttMessage to-message [input] "Instantiates an MQTT message from input"))

--- a/test/clojurewerkz/machine_head/client_test.clj
+++ b/test/clojurewerkz/machine_head/client_test.clj
@@ -1,4 +1,7 @@
 (ns clojurewerkz.machine-head.client-test
+  "BEWARE: Start RabbitMQ before running the rests, either locally or via Docker
+   (docker-compose build; docker-compose up)
+  "
   (:require [clojurewerkz.machine-head.client     :as mh]
             [clojurewerkz.machine-head.durability :as md]
             [clojure.test :refer :all])

--- a/test/clojurewerkz/machine_head/client_test.clj
+++ b/test/clojurewerkz/machine_head/client_test.clj
@@ -7,7 +7,9 @@
             [clojure.test :refer :all])
   (:import java.util.concurrent.atomic.AtomicInteger
            org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
-           (org.eclipse.paho.client.mqttv3 MqttConnectOptions)))
+           (org.eclipse.paho.client.mqttv3 MqttConnectOptions)
+           (javax.net SocketFactory)
+           (java.net InetAddress)))
 
 (def ci? (System/getenv "CI"))
 
@@ -30,13 +32,12 @@
   (dotimes [i 1]
     (let [called? (atom false)
           id  (format "mh.tests-%d" i)
-          p   (md/new-memory-persister)
           opt   (proxy
                   [MqttConnectOptions] []
                   (getConnectionTimeout []
                     (reset! called? true)
                     (proxy-super getConnectionTimeout)))
-          c   (mh/connect "tcp://127.0.0.1:1883" id p opt)]
+          c   (mh/connect "tcp://127.0.0.1:1883" id opt)]
       (is (mh/connected? c))
       (is (true? @called?))
       (mh/disconnect-and-close c))))
@@ -61,6 +62,25 @@
           w  {:topic "lw-topic" :payload (.getBytes "last will") :qos 0 :retain false}
           c  (mh/connect "tcp://127.0.0.1:1883" id {:clean-session true :will w})]
       (is (mh/connected? c))
+      (mh/disconnect-and-close c))))
+
+(deftest test-connection-with-socket-factory
+  (dotimes [i 1]
+    (let [called? (atom false)
+          id  (format "mh.tests-%d" i)
+          default (SocketFactory/getDefault)
+          f   (proxy [SocketFactory] []
+                  (createSocket
+                    ([]
+                     (reset! called? true) (.createSocket default))
+                    ([host port]
+                     (reset! called? true) (.createSocket default host port))
+                    ([address port localAddress localPort]
+                     (reset! called? true) (.createSocket default address port localAddress localPort))
+                    ))
+          c   (mh/connect "tcp://127.0.0.1:1883" id {:socket-factory f})]
+      (is (mh/connected? c))
+      (is (true? @called?))
       (mh/disconnect-and-close c))))
 
 


### PR DESCRIPTION
Added client option :auto-reconnect. When set to true, client will try to reconnect. More info on eclipse paho auto-reconnect: https://github.com/eclipse/paho.mqtt.java/issues/9
