### PR TITLE
Fix multiple subscribes

### DIFF
--- a/src/clojure/clojurewerkz/machine_head/client.clj
+++ b/src/clojure/clojurewerkz/machine_head/client.clj
@@ -36,12 +36,14 @@
 
     * :username (string)
     * :password (string or char array)
-    * :keep-alive-interval (int)
+    * :auto-reconnect (bool)
     * :connection-timeout (int)
     * :clean-session (bool)
+    * :keep-alive-interval (int)
+    * :max-inflight (int)
     * :socket-factory (SocketFactory)
     * :will {:topic :payload :qos :retain}
-    * :auto-reconnect (bool)"
+    "
   ([^String uri]
     (connect uri {}))
   ([^String uri

--- a/src/clojure/clojurewerkz/machine_head/conversion.clj
+++ b/src/clojure/clojurewerkz/machine_head/conversion.clj
@@ -22,6 +22,8 @@
        (.setConnectionTimeout o (Integer/valueOf t)))
      (when-not (nil? (:clean-session m))
        (.setCleanSession o (:clean-session m)))
+     (when-let [m (:max-inflight m)]
+       (.setMaxInflight o m))
      (when-let [f (:socket-factory m)]
        (.setSocketFactory o f))
      (when-let [will (:will m)]

--- a/test/clojurewerkz/machine_head/client_test.clj
+++ b/test/clojurewerkz/machine_head/client_test.clj
@@ -6,23 +6,22 @@
             [clojurewerkz.machine-head.durability :as md]
             [clojure.test :refer :all])
   (:import java.util.concurrent.atomic.AtomicInteger
-           org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
            (org.eclipse.paho.client.mqttv3 MqttConnectOptions)
            (javax.net SocketFactory)
-           (java.net InetAddress)))
+           (java.util.concurrent TimeUnit)))
 
 (def ci? (System/getenv "CI"))
 
 (deftest test-connection
   (dotimes [i 50]
-    (let [id (format "mh.tests-%d" i)
+    (let [id (format "mh/tests-%d" i)
           c  (mh/connect "tcp://127.0.0.1:1883" id)]
       (is (mh/connected? c))
       (mh/disconnect-and-close c))))
 
 (deftest test-connection-with-provided-persister
   (dotimes [i 10]
-    (let [id  (format "mh.tests-%d" i)
+    (let [id  (format "mh/tests-%d" i)
           p   (md/new-memory-persister)
           c   (mh/connect "tcp://127.0.0.1:1883" id p {})]
       (is (mh/connected? c))
@@ -31,7 +30,7 @@
 (deftest test-connection-with-provided-options
   (dotimes [i 1]
     (let [called? (atom false)
-          id  (format "mh.tests-%d" i)
+          id  (format "mh/tests-%d" i)
           opt   (proxy
                   [MqttConnectOptions] []
                   (getConnectionTimeout []
@@ -44,21 +43,21 @@
 
 (deftest test-connection-with-clean-session
   (dotimes [i 50]
-    (let [id (format "mh.tests-%d" i)
+    (let [id (format "mh/tests-%d" i)
           c  (mh/connect "tcp://127.0.0.1:1883" id {:clean-session true})]
       (is (mh/connected? c))
       (mh/disconnect-and-close c))))
 
 (deftest test-connection-with-connection-timeout
   (dotimes [i 50]
-    (let [id (format "mh.tests-%d" i)
+    (let [id (format "mh/tests-%d" i)
           c  (mh/connect "tcp://127.0.0.1:1883" id {:connection-timeout 10})]
       (is (mh/connected? c))
       (mh/disconnect-and-close c))))
 
 (deftest test-connection-with-last-will
   (dotimes [i 50]
-    (let [id (format "mh.tests-%d" i)
+    (let [id (format "mh/tests-%d" i)
           w  {:topic "lw-topic" :payload (.getBytes "last will") :qos 0 :retain false}
           c  (mh/connect "tcp://127.0.0.1:1883" id {:clean-session true :will w})]
       (is (mh/connected? c))
@@ -67,7 +66,7 @@
 (deftest test-connection-with-socket-factory
   (dotimes [i 1]
     (let [called? (atom false)
-          id  (format "mh.tests-%d" i)
+          id  (format "mh/tests-%d" i)
           default (SocketFactory/getDefault)
           f   (proxy [SocketFactory] []
                   (createSocket
@@ -85,28 +84,28 @@
 
 
 (deftest test-publishing-empty-messages
-  (let [c (mh/connect "tcp://127.0.0.1:1883" "mh.tests-1")]
+  (let [c (mh/connect "tcp://127.0.0.1:1883" "mh/tests-1")]
     (is (mh/connected? c))
     (dotimes [i 1000]
-      (mh/publish c "mh.topic1" nil))
+      (mh/publish c "mh/topic1" nil))
     (mh/disconnect c)))
 
 (deftest test-publishing-messages
-  (let [c (mh/connect "tcp://127.0.0.1:1883" "mh.tests-1")]
+  (let [c (mh/connect "tcp://127.0.0.1:1883" "mh/tests-1")]
     (is (mh/connected? c))
     (dotimes [i 1000]
-      (mh/publish c "mh.topic1" "hello"))
+      (mh/publish c "mh/topic1" "hello"))
     (mh/disconnect c)))
 
 (deftest test-basic-topic-subscription
   (let [id (mh/generate-id)
         c  (mh/connect "tcp://127.0.0.1:1883" id)
         i  (AtomicInteger.)]
-    (mh/subscribe c {"mh.topic" 0} (fn [^String topic meta ^bytes payload]
+    (mh/subscribe c {"mh/topic" 0} (fn [^String topic meta ^bytes payload]
                                      (.incrementAndGet i)))
     (is (mh/connected? c))
     (dotimes [_ 100]
-      (mh/publish c "mh.topic" "payload"))
+      (mh/publish c "mh/topic" "payload"))
     (Thread/sleep 100)
     (is (= 100 (.get i)))
     (mh/disconnect c)))
@@ -117,11 +116,11 @@
         i  (AtomicInteger.)
         f  (fn [^String topic meta ^bytes payload]
              (.incrementAndGet i))
-        m  {"mh.topic" 0}]
+        m  {"mh/topic" 0}]
     (mh/subscribe c1 m f)
     (mh/subscribe c2 m f)
     (dotimes [_ 100]
-      (mh/publish c1 "mh.topic" "payload"))
+      (mh/publish c1 "mh/topic" "payload"))
     (Thread/sleep 250)
     (is (= 200 (.get i)))
     (mh/disconnect c1)
@@ -165,14 +164,14 @@
   (let [id (mh/generate-id)
         c  (mh/connect "tcp://127.0.0.1:1883" id)
         i  (AtomicInteger.)]
-    (mh/subscribe c {"mh.topic1" 0 "mh.topic2" 0}
+    (mh/subscribe c {"mh/topic1" 0 "mh/topic2" 0}
                   (fn [^String topic meta ^bytes payload]
                     (.incrementAndGet i)))
     (is (mh/connected? c))
     (dotimes [_ 50]
-      (mh/publish c "mh.topic1" "payload"))
+      (mh/publish c "mh/topic1" "payload"))
     (dotimes [_ 60]
-      (mh/publish c "mh.topic2" "payload"))
+      (mh/publish c "mh/topic2" "payload"))
     (Thread/sleep 100)
     (is (= 110 (.get i)))
     (mh/disconnect c)))
@@ -183,12 +182,12 @@
   (let [id (mh/generate-id)
         c  (mh/connect "tcp://127.0.0.1:1883" id)
         i  (AtomicInteger.)]
-    (mh/subscribe c {"mh.topic" 1}
+    (mh/subscribe c {"mh/topic" 1}
                   (fn [^String topic meta ^bytes payload]
                     (.incrementAndGet i)))
     (is (mh/connected? c))
     (dotimes [_ 100]
-      (mh/publish c "mh.topic" "payload"))
+      (mh/publish c "mh/topic" "payload"))
     (Thread/sleep 100)
     (is (= 100 (.get i)))
     (mh/disconnect c)))
@@ -198,16 +197,16 @@
   (let [id (mh/generate-id)
         c  (mh/connect "tcp://127.0.0.1:1883" id)
         i  (AtomicInteger.)]
-    (mh/subscribe c {"mh.topic1" 0 "mh.topic3" 1}
+    (mh/subscribe c {"mh/topic1" 0 "mh/topic3" 1}
                   (fn [^String topic meta ^bytes payload]
                     (.incrementAndGet i)))
     (is (mh/connected? c))
     (dotimes [_ 100]
-      (mh/publish c "mh.topic1" "payload"))
+      (mh/publish c "mh/topic1" "payload"))
     (dotimes [_ 100]
-      (mh/publish c "mh.topic2" "payload"))
+      (mh/publish c "mh/topic2" "payload"))
     (dotimes [_ 100]
-      (mh/publish c "mh.topic3" "payload"))
+      (mh/publish c "mh/topic3" "payload"))
     (Thread/sleep 100)
     (is (= 200 (.get i)))
     (mh/disconnect c)))
@@ -216,13 +215,13 @@
   (let [id (mh/generate-id)
         c  (mh/connect "tcp://127.0.0.1:1883" id)
         i  (AtomicInteger.)]
-    (mh/subscribe c {"mh.temp-topic" 0}
+    (mh/subscribe c {"mh/temp-topic" 0}
                   (fn [^String topic meta ^bytes payload]
                     (.incrementAndGet i)))
-    (mh/unsubscribe c ["mh.temp-topic"])
+    (mh/unsubscribe c ["mh/temp-topic"])
     (is (mh/connected? c))
     (dotimes [_ 100]
-      (mh/publish c "mh.temp-topic" "payload"))
+      (mh/publish c "mh/temp-topic" "payload"))
     (is (= 0 (.get i)))
     (mh/disconnect c)))
 
@@ -231,20 +230,20 @@
   (let [id (mh/generate-id)
         c  (mh/connect "tcp://127.0.0.1:1883" id)
         i  (AtomicInteger.)]
-    (mh/subscribe c {"mh.temp-topic1" 0
-                     "mh.temp-topic2" 0
-                     "mh.temp-topic3" 0}
+    (mh/subscribe c {"mh/temp-topic1" 0
+                     "mh/temp-topic2" 0
+                     "mh/temp-topic3" 0}
                      (fn [^String topic meta ^bytes payload]
                        (.incrementAndGet i)))
-    (mh/unsubscribe c ["mh.temp-topic1"
-                       "mh.temp-topic2"])
+    (mh/unsubscribe c ["mh/temp-topic1"
+                       "mh/temp-topic2"])
     (is (mh/connected? c))
     (dotimes [_ 10]
-      (mh/publish c "mh.temp-topic1" "payload"))
+      (mh/publish c "mh/temp-topic1" "payload"))
     (dotimes [_ 10]
-      (mh/publish c "mh.temp-topic2" "payload"))
+      (mh/publish c "mh/temp-topic2" "payload"))
     (dotimes [_ 10]
-      (mh/publish c "mh.temp-topic3" "payload"))
+      (mh/publish c "mh/temp-topic3" "payload"))
     (Thread/sleep 50)
     (is (= 10 (.get i)))
     (mh/disconnect c)))
@@ -254,12 +253,12 @@
   (let [c (mh/connect "tcp://127.0.0.1:1883" (mh/generate-id))]
     (is (mh/connected? c))
     (dotimes [i 1000]
-      (mh/publish c "mh.qos.topic1" "hello" 0))
+      (mh/publish c "mh/qos.topic1" "hello" 0))
     (mh/disconnect c)))
 
 (deftest test-publishing-messages-with-qos-1
   (let [c (mh/connect "tcp://127.0.0.1:1883" (mh/generate-id))]
     (is (mh/connected? c))
     (dotimes [i 1000]
-      (mh/publish c "mh.qos.topic1" "hello" 1))
+      (mh/publish c "mh/qos.topic1" "hello" 1))
     (mh/disconnect c)))


### PR DESCRIPTION
Fix #13 while also:

- refactor `connect` to take `uri` + map of options
- moving `.setCallback` to `connect`
- fix tests to use topic names that don't conflict with RabbitMQ