### PR TITLE
Correct max-inflight option

### DIFF
--- a/src/clojure/clojurewerkz/machine_head/client.clj
+++ b/src/clojure/clojurewerkz/machine_head/client.clj
@@ -40,7 +40,7 @@
     * :connection-timeout (int)
     * :clean-session (bool)
     * :keep-alive-interval (int)
-    * :max-in-flight (int)
+    * :max-inflight (int)
     * :socket-factory (SocketFactory)
     * :will {:topic :payload :qos :retain}
     "

--- a/test/clojurewerkz/machine_head/client_test.clj
+++ b/test/clojurewerkz/machine_head/client_test.clj
@@ -14,7 +14,7 @@
 (def ci? (System/getenv "CI"))
 
 (defn connect []
-  (mh/connect "tcp://127.0.0.1:1883" {:opts {:max-in-flight 50000}}))
+  (mh/connect "tcp://127.0.0.1:1883" {:opts {:max-inflight 50000}}))
 
 (deftest test-connection
   (dotimes [i 50]
@@ -186,7 +186,7 @@
     (mh/disconnect c)))
 
 (deftest test-multi-topic-subscription
-  (let [c  (mh/connect "tcp://127.0.0.1:1883" {:opts {:max-in-flight 1000}})
+  (let [c  (mh/connect "tcp://127.0.0.1:1883" {:opts {:max-inflight 1000}})
         i  (AtomicInteger.)]
     (mh/subscribe c {"mh/topic1" 0 "mh/topic2" 0}
                   (fn [^String topic meta ^bytes payload]
@@ -201,7 +201,7 @@
     (mh/disconnect c)))
 
 (deftest test-different-subscriptions-different-handlers
-  (let [c  (mh/connect "tcp://127.0.0.1:1883" {:opts {:max-in-flight 1000}})
+  (let [c  (mh/connect "tcp://127.0.0.1:1883" {:opts {:max-inflight 1000}})
         countDownOne (CountDownLatch. 50)
         countDownTwo (CountDownLatch. 60)]
     (mh/subscribe c {"mh/topic1" 0}


### PR DESCRIPTION
In-correct option name `:max-in-flight` is used in test code and a comment. 

As a result, the call to `setMaxInflight` in the underlying Paho library is not invoked and the default value of 10 will be used.  

For developers who looks a tests as a means of understanding how to use a library/technology this can lead them into issues such as `Too many publishes in progress (32202)` errors due to back-pressure from MQTT brokers. 