### PR TITLE
Update Paho client to latest version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject clojurewerkz/machine_head "1.1.0-SNAPSHOT"
   :description "Clojure MQTT client"
   :dependencies [[org.clojure/clojure          "1.8.0"]
-                 [org.eclipse.paho/org.eclipse.paho.client.mqttv3 "1.1.0"]
+                 [org.eclipse.paho/org.eclipse.paho.client.mqttv3 "1.2.1"]
                  [clojurewerkz/support         "1.1.0"]]
   :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}


### PR DESCRIPTION
I have added the new Paho driver, all the tests pass. It seems to include the V5 of the client as well, but I haven't tested this.