### PR TITLE
Adds support for custom headers for MQTT connection over WebSockets

### DIFF
--- a/src/clojure/clojurewerkz/machine_head/conversion.clj
+++ b/src/clojure/clojurewerkz/machine_head/conversion.clj
@@ -25,6 +25,7 @@
           :auto-reconnect      :>> #(.setAutomaticReconnect o %)
           :server-uris         :>> #(.setServerURIs o (into-array String %))
           :ssl-properties      :>> #(.setSSLProperties o (map->properties %))
+          :custom-websocket-headers :>> #(.setCustomWebSocketHeaders o (map->properties %))
           :mqtt-version        :>> #(.setMqttVersion
                                       o (case %
                                           "3.1"

--- a/test/clojurewerkz/machine_head/conversion_test.clj
+++ b/test/clojurewerkz/machine_head/conversion_test.clj
@@ -16,6 +16,7 @@
               :auto-reconnect      true
               :server-uris         ["ssl://mqtt.example.com"]
               :ssl-properties      {"com.ibm.ssl.protocol" "SSLv3"}
+              :custom-websocket-headers {"X-Custom-Header" "foo"}
               :mqtt-version        "3.1.1"
               :will                {:topic   "will"
                                     :qos     0
@@ -32,6 +33,7 @@
                        :auto-reconnect      (.isAutomaticReconnect o)
                        :server-uris         (vec (.getServerURIs o))
                        :ssl-properties      (properties->map (.getSSLProperties o))
+                       :custom-websocket-headers (properties->map (.getCustomWebSocketHeaders o))
                        :mqtt-version        (condp = (.getMqttVersion o)
                                               MqttConnectOptions/MQTT_VERSION_3_1
                                               "3.1"


### PR DESCRIPTION
In some cases it is required to send custom headers, for example if you want to connect to AWS IoT broker.

```setCustomWebSocketHeaders``` is available since version 1.2.1.