### PR TITLE
1.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ definition to your `pom.xml`:
 
 With Leiningen:
 
-    [clojurewerkz/machine_head "1.0.0"]
+    [clojurewerkz/machine_head "1.1.0"]
 
 
 With Maven:
@@ -57,7 +57,7 @@ With Maven:
     <dependency>
       <groupId>clojurewerkz</groupId>
       <artifactId>machine_head</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.0</version>
     </dependency>
 
 

--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -21,12 +21,12 @@ This work is licensed under a <a rel="license" href="http://creativecommons.org/
 
 ## What version of Machine Head does this guide cover?
 
-This guide covers Machine Head 1.0.0.
+This guide covers Machine Head 1.1.0.
 
 
 ## Supported Clojure Versions
 
-Machine Head requires Clojure 1.4+. The latest stable release is recommended.
+Machine Head requires Clojure 1.8+. The latest stable release is recommended.
 
 
 ## Supported MQTT Brokers
@@ -109,7 +109,7 @@ Machine Head artifacts are [released to Clojars](https://clojars.org/clojurewerk
 Add the dependency:
 
 ``` clojure
-[clojurewerkz/machine_head "1.0.0"]
+[clojurewerkz/machine_head "1.1.0"]
 ```
 
 ### With Maven
@@ -133,7 +133,7 @@ And then the dependency:
 <dependency>
   <groupId>clojurewerkz</groupId>
   <artifactId>machine_head</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,23 +1,27 @@
-(defproject clojurewerkz/machine_head "1.1.0-SNAPSHOT"
+(defproject clojurewerkz/machine_head "1.1.0"
   :description "Clojure MQTT client"
   :dependencies [[org.clojure/clojure          "1.8.0"]
                  [org.eclipse.paho/org.eclipse.paho.client.mqttv3 "1.2.5"]
                  [clojurewerkz/support         "1.5.0"]
                  [clojurewerkz/propertied      "1.3.0"]]
   :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]}
+             :master {:dependencies [[org.clojure/clojure "1.12.0-master-SNAPSHOT"]]}
              :dev {:resource-paths ["test/resources"]
-                   :plugins [[codox "0.8.10"]]
+                   :plugins [[codox/codox "0.10.8"]]
                    :codox {:sources ["src/clojure"]
                            :output-dir "doc/api"}}}
-  :aliases {"all" ["with-profile" "dev:dev,1.7:dev,master"]}
+  :aliases {"all" ["with-profile" "dev:dev,1.7:dev,1.8:dev,1.9:dev,1.10:dev,1.11:dev,master"]}
   :repositories {"eclipse-paho" {:url "https://repo.eclipse.org/content/repositories/paho-releases/"
                                  :snapshots false
                                  :releases {:checksum :fail}}
-                 "sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
+                 "sonatype" {:url "https://oss.sonatype.org/content/repositories/releases"
                              :snapshots false
                              :releases {:checksum :fail :update :always}}
-                 "sonatype-snapshots" {:url "http://oss.sonatype.org/content/repositories/snapshots"
+                 "sonatype-snapshots" {:url "https://oss.sonatype.org/content/repositories/snapshots"
                                        :snapshots true
                                        :releases {:checksum :fail :update :always}}}
   :javac-options      ["-target" "1.6" "-source" "1.6"]


### PR DESCRIPTION
It's been nearly 6 years since the latest release (1.0.0). In the mean time Pahoo has released several new versions with some fixes. And there are already a couple of commits exposing new options for the connect operation.

Also, expand out test matrix to cover the Clojure versions that have appeared in the meantime, and the minimum supported Clojure version.

Finally, use HTTPS URLs for the artifact repositories. Some of them don't support plain HTTP at all (for good reasons!)

This commit should help close #38.